### PR TITLE
Fixed version constraint for debugbar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "OSL-3.0"
   ],
   "require": {
-    "maximebf/debugbar": "~1.12.0"
+    "maximebf/debugbar": "1.12.*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Version constraint of debugbar has an issue, if following the simver version standard you should use ~1.12 or use ^1.12.0. This is because composer will see 1.12 as major version instead of 1 as it should. You van use https://semver.mwl.be/#?package=maximebf%2Fdebugbar&version=%5E1.12&minimum-stability=stable to test out version constraints
