### PR TITLE
Implement storage for requests

### DIFF
--- a/Controller/OpenHandler/Handle.php
+++ b/Controller/OpenHandler/Handle.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace MagentoHackathon\Toolbar\Controller\OpenHandler;
+
+use MagentoHackathon\Toolbar\Toolbar;
+use DebugBar\OpenHandler;
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\Result\Raw;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Controller\ResultInterface;
+
+class Handle extends Action
+{
+    /** @var Toolbar  */
+    protected $toolbar;
+
+    public function __construct(Context $context, Toolbar $toolbar)
+    {
+        $this->toolbar = $toolbar;
+
+        parent::__construct($context);
+    }
+
+    /**
+     * Dispatch request
+     *
+     * @return \Magento\Framework\Controller\ResultInterface|ResponseInterface
+     * @throws \Magento\Framework\Exception\NotFoundException
+     */
+    public function execute()
+    {
+        /** @var Raw $result */
+        $result = $this->resultFactory->create(ResultFactory::TYPE_RAW);
+        $result->setHeader('content-type', 'application/json');
+
+        $openHandler = new OpenHandler($this->toolbar);
+        $data = $openHandler->handle(null, false, false);
+
+        $result->setContents($data);
+
+        return $result;
+    }
+}

--- a/Storage/FilesystemStorage.php
+++ b/Storage/FilesystemStorage.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace MagentoHackathon\Toolbar\Storage;
+
+use DebugBar\Storage\StorageInterface;
+use Magento\Framework\Filesystem;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem\Directory\ReadInterface;
+
+class FilesystemStorage implements StorageInterface
+{
+    /** @var Filesystem */
+    protected $filesystem;
+
+    protected $dirname = 'toolbar';
+
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Saves collected data
+     *
+     * @param string $id
+     * @param string $data
+     */
+    function save($id, $data)
+    {
+        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
+
+        if ($directory->create($this->dirname)) {
+            $path = $this->makeFilename($id);
+
+            $file = $directory->openFile($path);
+            try {
+                $file->write(json_encode($data));
+            } finally {
+                $file->close();
+            }
+        }
+    }
+
+    /**
+     * Returns collected data with the specified id
+     *
+     * @param string $id
+     * @return array
+     */
+    function get($id)
+    {
+        $directory = $this->filesystem->getDirectoryRead(DirectoryList::VAR_DIR);
+
+        return $this->loadFile($directory, $this->makeFilename($id));
+    }
+
+    /**
+     * Returns a metadata about collected data
+     *
+     * @param array $filters
+     * @param integer $max
+     * @param integer $offset
+     * @return array
+     */
+    function find(array $filters = array(), $max = 20, $offset = 0)
+    {
+        $directory = $this->filesystem->getDirectoryRead(DirectoryList::VAR_DIR);
+
+        $i = 0;
+        $results = array();
+        foreach ($directory->search('*.json', $this->dirname) as $path)
+        {
+            if ($i++ < $offset && empty($filters)) {
+                $results[] = null;
+                continue;
+            }
+
+            $data = $this->loadFile($directory, $path);
+            $meta = $data['__meta'];
+            unset($data);
+            if ($this->filter($meta, $filters)) {
+                $results[] = $meta;
+            }
+            if (count($results) >= ($max + $offset)) {
+                break;
+            }
+        }
+
+        return array_slice($results, $offset, $max);
+    }
+
+    /**
+     * Filter the metadata for matches.
+     *
+     * @param $meta
+     * @param $filters
+     * @return bool
+     */
+    protected function filter($meta, $filters)
+    {
+        foreach ($filters as $key => $value) {
+            if (!isset($meta[$key]) || fnmatch($value, $meta[$key]) === false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Clears all the collected data
+     */
+    function clear()
+    {
+        $directory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
+        $directory->delete($this->dirname);
+    }
+
+     /**
+      * Create the filename for the data, based on the id.
+      *
+      * @param $id
+      * @return string
+      */
+    protected function makeFilename($id)
+    {
+        return $this->dirname . DIRECTORY_SEPARATOR . basename($id) . ".json";
+    }
+
+    protected function loadFile(ReadInterface $directory, $path)
+    {
+        if ($directory->isExist($path)) {
+            $file = $directory->openFile($path);
+
+            $contents = '';
+            while( ! $file->eof()) {
+                $contents .= $file->read(8192);
+            }
+            return json_decode($contents, true);
+        }
+    }
+}

--- a/Storage/FilesystemStorage.php
+++ b/Storage/FilesystemStorage.php
@@ -14,6 +14,11 @@ class FilesystemStorage implements StorageInterface
 
     protected $dirname = 'toolbar';
 
+    /**
+     * FilesystemStorage constructor.
+     *
+     * @param Filesystem $filesystem
+     */
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem = $filesystem;
@@ -25,7 +30,7 @@ class FilesystemStorage implements StorageInterface
      * @param string $id
      * @param string $data
      */
-    function save($id, $data)
+    public function save($id, $data)
     {
         $directory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
 
@@ -47,7 +52,7 @@ class FilesystemStorage implements StorageInterface
      * @param string $id
      * @return array
      */
-    function get($id)
+    public function get($id)
     {
         $directory = $this->filesystem->getDirectoryRead(DirectoryList::VAR_DIR);
 
@@ -62,7 +67,7 @@ class FilesystemStorage implements StorageInterface
      * @param integer $offset
      * @return array
      */
-    function find(array $filters = array(), $max = 20, $offset = 0)
+    public function find(array $filters = array(), $max = 20, $offset = 0)
     {
         $directory = $this->filesystem->getDirectoryRead(DirectoryList::VAR_DIR);
 
@@ -109,7 +114,7 @@ class FilesystemStorage implements StorageInterface
     /**
      * Clears all the collected data
      */
-    function clear()
+    public function clear()
     {
         $directory = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
         $directory->delete($this->dirname);
@@ -126,6 +131,13 @@ class FilesystemStorage implements StorageInterface
         return $this->dirname . DIRECTORY_SEPARATOR . basename($id) . ".json";
     }
 
+    /**
+     * Read a file into a stringß.ß
+     *
+     * @param ReadInterface $directory
+     * @param $path
+     * @return mixed
+     */
     protected function loadFile(ReadInterface $directory, $path)
     {
         if ($directory->isExist($path)) {


### PR DESCRIPTION
This is the initial implementation of storage for the Debugbar. Uses the Magento filesystem to read/write files to the var folder. These files can be accessed through the API, using the browser button (3rd on the right of the toolbar).

Skips the collecting on internal routes, doesn't inject on ajax calls.

Possible future additions:
- Garbage collections (cleanup old files), could be done during cron?
- Database/Redis storage could be faster, but because it's development, not really needed.
- Data can be stacked, eg. for redirects and ajax calls. Not yet implemented here though.
