### PR TITLE
Add toolbar() helper function

### DIFF
--- a/Toolbar.php
+++ b/Toolbar.php
@@ -68,6 +68,23 @@ class Toolbar extends DebugBar
     }
 
     /**
+     * Adds a message to the MessagesCollector
+     *
+     * A message can be anything from an object to a string
+     *
+     * @param mixed $message
+     * @param string $label
+     */
+    public function addMessage($message, $label = 'info')
+    {
+        if ($this->hasCollector('messages')) {
+            /** @var \MagentoHackathon\Toolbar\DataCollector\MessagesCollector $collector */
+            $collector = $this->getCollector('messages');
+            $collector->addMessage($message, $label);
+        }
+    }
+
+    /**
      * Get the JavascriptRenderer
      *
      * @param string|null $baseUrl

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
       "MagentoHackathon\\Toolbar\\": ""
     },
     "files": [
-      "registration.php"
+      "registration.php",
+      "helpers.php"
     ]
   }
 }

--- a/helpers.php
+++ b/helpers.php
@@ -1,0 +1,21 @@
+<?php
+
+if ( ! function_exists('toolbar')) {
+
+    /**
+     * @param mixed|null ...$args
+     * @return MagentoHackathon\Toolbar\Toolbar
+     */
+    function toolbar($args = null)
+    {
+        /** @var \MagentoHackathon\Toolbar\Toolbar $toolbar */
+        $toolbar = \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(\MagentoHackathon\Toolbar\Toolbar::class);
+
+        foreach (func_get_args() as $value) {
+            $toolbar->addMessage($value);
+        }
+
+        return $toolbar;
+    }
+}


### PR DESCRIPTION
So this might raise a few red flags, because I think the static call to the ObjectManager is discouraged, but this adds a small helper for development only, to easily add a message.

```
toolbar(); // The Toolbar instance
toolbar($object); // Add $object to the messages
toolbar($object, $string, $other); // Add multiple items to the message collector
```

Obviously this isn't for 3rd party modules or something, but more as developer, you might want to check the result before/after some call, without interrupting the output. And injecting the Toolbar for just a quick check is much more cumbersome then calling a global function..

(Could also add more convenient functions like start/stop measurements, to experiment with timing)
